### PR TITLE
chore: Remove discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3
 
 We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
 
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
+If you are not familiar with the different technologies used in this project, please refer to the respective docs. 
 
 - [Next.js](https://nextjs.org)
 - [NextAuth.js](https://next-auth.js.org)


### PR DESCRIPTION
Confusing to your users, who think they can get support in our discord not realizing that the link is for support with create-t3-app